### PR TITLE
bug fix that removes nonexistent `-a 256` option for `sha256sum`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -107,14 +107,14 @@ fi
 
 # Update the clickhouse user override file, it accepts the sha256 of the password
 KAWA_DB_PASSWORD=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 16)
-kawa_hashed_db_password=$(echo -n "$KAWA_DB_PASSWORD" | sha256sum -a 256 | cut -d ' ' -f 1)
+kawa_hashed_db_password=$(echo -n "$KAWA_DB_PASSWORD" | sha256sum | cut -d ' ' -f 1)
 sed -i "s/.*password_sha256.*/<password_sha256_hex>$kawa_hashed_db_password<\/password_sha256_hex>/g" ./assets/users.d/kawa.xml
 
 master_key=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 16)
 kawa_clickhouse_db_name="default"
 
 KAWA_DB_USER="kawa"
-KAWA_RUNNER_AES_KEY=$(head /dev/urandom | sha256sum -a 256 | cut -d ' ' -f 1)
+KAWA_RUNNER_AES_KEY=$(head /dev/urandom | sha256sum | cut -d ' ' -f 1)
 KAWA_ENCRYPTION_KEY=$(echo -n "${master_key}-key" | sha256sum | awk '{print substr($1, 1, 24)}')
 KAWA_ENCRYPTION_IV=$(echo -n "${master_key}-iv" | sha256sum | awk '{print substr($1, 1, 16)}')
 KAWA_ACCESS_TOKEN_SECRET=$(head -c 64 /dev/urandom | xxd -p | tr -d '\n')


### PR DESCRIPTION
bug fix that removes nonexistent `-a 256` option for `sha256sum`